### PR TITLE
Update readme with v5 meeting cadence, and ad hoc meeting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,20 @@
 
 This repository is used for generalized Express.js discussions.
 
-* [Current discussions](https://github.com/expressjs/discussions/issues?q=is%3Aissue+is%3Aopen+label%3Adiscuss)
-* [Upcoming meetings](https://github.com/expressjs/discussions/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Ameeting)
+- [Current discussions](https://github.com/expressjs/discussions/issues?q=is%3Aissue+is%3Aopen+label%3Adiscuss)
+- [Upcoming meetings](https://github.com/expressjs/discussions/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Ameeting)
+
+## Current v5 Meeting Cadence
+
+While focusing on releasing Express v5, the meeting schedule has been changed from the normal schedule listed below. Until further notice, meetings will be held on this cadence.
+
+**Currently, meetings are held weekly on Thursdays at 4pm GMT.**
+
+### If Stakeholders Not Available
+
+If for some reason the host of the meeting is not available, but there are participants who wish to discuss the agenda or other topics, an ad hoc meeting can be started. If the host is not available for a scheduled meeting, participants can post a link to a video chat in the scheduled meeting's issue.
+
+Meetings should be recorded when appropriate, like regular meetings are, and provided to the TC for uploading to the official youtube channel.
 
 ## Express.js TC meetings
 
@@ -12,4 +24,4 @@ a live stream of the discussion and a recording of past meetings. Topics for the
 meetings are determined on an as-needed basis and may be technical or management
 of nature.
 
-Current meeting schedule: Wednesdays 23:30 UTC
+Normal meeting schedule: Wednesdays 23:30 UTC

--- a/README.md
+++ b/README.md
@@ -2,20 +2,26 @@
 
 This repository is used for generalized Express.js discussions.
 
-- [Current discussions](https://github.com/expressjs/discussions/issues?q=is%3Aissue+is%3Aopen+label%3Adiscuss)
-- [Upcoming meetings](https://github.com/expressjs/discussions/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Ameeting)
+* [Current discussions](https://github.com/expressjs/discussions/issues?q=is%3Aissue+is%3Aopen+label%3Adiscuss)
+* [Upcoming meetings](https://github.com/expressjs/discussions/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Ameeting)
 
 ## Current v5 Meeting Cadence
 
-While focusing on releasing Express v5, the meeting schedule has been changed from the normal schedule listed below. Until further notice, meetings will be held on this cadence.
+While focusing on releasing Express v5, the meeting schedule has been changed
+from the normal schedule listed below. Until further notice, meetings will be
+held on this cadence.
 
 **Currently, meetings are held weekly on Thursdays at 4pm GMT.**
 
 ### If Stakeholders Not Available
 
-If for some reason the host of the meeting is not available, but there are participants who wish to discuss the agenda or other topics, an ad hoc meeting can be started. If the host is not available for a scheduled meeting, participants can post a link to a video chat in the scheduled meeting's issue.
+If for some reason the host of the meeting is not available, but there are
+participants who wish to discuss the agenda or other topics, an ad hoc meeting
+can be started. If the host is not available for a scheduled meeting,
+participants can post a link to a video chat in the scheduled meeting's issue.
 
-Meetings should be recorded when appropriate, like regular meetings are, and provided to the TC for uploading to the official youtube channel.
+Meetings should be recorded when appropriate, like regular meetings are, and
+provided to the TC for uploading to the official youtube channel.
 
 ## Express.js TC meetings
 


### PR DESCRIPTION
In reference to https://github.com/expressjs/discussions/issues/107#issuecomment-598300865

Please suggest any edits inline, wanted to make sure I opened a PR since I brought up these points.

> **Takeaways:**
> 
> * A meeting was assumed to happen today because we said two meetings ago that we were going to do weekly meetings to check in on v5
> * I don't believe we officially documented that decision, or the schedule, outside of issue comments or a recording
> * There wasn't a pending issue to track the next meeting, so folks (like myself) weren't sure if it was official. 
> * Without key stakeholders (permissions for zoom, streaming), it's unclear how to proceed with an ad hoc meeting if some folks want to hold one
> 
> **Remedies:**
> 
> * Make sure meeting cadence is committed to the readme, update it when cadence changes (e.g. when we put forward doing weekly)
> * Make sure issues are generated to track a meeting. I'm in favor of anyone being able to create them (since they are easily editable/close-able), and suggest it is part of the wrap up of any given meeting. Issues are generated automatically w/ the Node.js projects based on a calendar and [some templates](https://github.com/nodejs/create-node-meeting-artifacts), which we could set up eventually, but let's not overengineer things too early.
> * Document procedure for holding ad hoc meetings, or in the case that the main stakeholders aren't available. Can just be `If stakeholders aren't available, start a google hangout, post the link, and have someone record it`