### PR TITLE
feat: use pkgjs/meet to generate meeting agenda

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-tc.md
+++ b/.github/ISSUE_TEMPLATE/meeting-tc.md
@@ -1,0 +1,43 @@
+## Date/Time
+
+| Timezone | Date/Time |
+|----------|-----------|
+<%= [
+  'America/Los_Angeles',
+  'America/Denver',
+  'America/Chicago',
+  'America/New_York',
+  'Europe/London',
+  'Europe/Amsterdam',
+  'Europe/Moscow',
+  'Asia/Kolkata',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Australia/Sydney'
+].map((zone) => {
+  return `| ${zone} | ${date.setZone(zone).toFormat('EEE dd-MMM-yyyy HH:mm (hh:mm a)')} |`
+}).join('\n') %>
+
+Or in your local time:
+* https://www.timeanddate.com/worldclock/?iso=<%= date.toFormat("yyyy-MM-dd'T'HH:mm:ss") %>
+
+## Agenda
+
+Extracted from **<%= agendaLabel %>** labelled issues and pull requests from **<%= owner %>/<%= repo %>** prior to the meeting.
+
+<%= agendaIssues.map((i) => {
+  return `* ${i.html_url}`
+}).join('\n') %>
+
+## Invited
+
+@expressjs/express-tc
+
+## Links
+
+* Minutes:
+
+### Joining the meeting
+
+* link for participants: TBD
+* For those who just want to watch: TBD

--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -1,0 +1,26 @@
+name: Schedule Meetings
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 1'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Technical Committee
+        uses: 'pkgjs/meet@v0'
+        with:
+          issueTitle: '<%= date.toFormat("yyyy-MM-dd") %> Express TC Meeting'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          orgs: expressjs,pillarjs,jshttp
+          agendaLabel: 'top priority'
+          meetingLabels: 'meeting'
+          # We alternate between two time slots:
+          # 1. Starting on 2024-03-04 at 9pm UTC (2024-03-04T21:00:00.0Z) with a period of 4 weeks (P4W)
+          # 2. Starting on 2024-03-20 at 9pm UTC (2024-03-20T21:00:00.0Z) with a period of 4 weeks (P4W)
+          schedules: '2024-03-04T21:00:00.0Z/P4W,2024-03-20T21:00:00.0Z/P4W'
+          createWithin: 'P1W'
+          issueTemplate: 'meeting-tc.md'


### PR DESCRIPTION
I added support in `pkgjs/meet` for generating meeting agendas. I hope this works well, I tested in a personal repo and it seems to. We will want to edit the template and stuff with the right links but I wanted to make sure this was all working first.