### PR TITLE
ci: follow 'agenda' label

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -30,7 +30,7 @@ jobs:
           issueTitle: '<%= date.toFormat("yyyy-MM-dd") %> Express Working Session'
           token: ${{ secrets.GITHUB_TOKEN }}
           orgs: expressjs,pillarjs,jshttp
-          agendaLabel: 'top priority'
+          agendaLabel: 'top priority, agenda'
           meetingLabels: 'meeting'
           # Converting the second time slot to a "working session"
           # https://github.com/expressjs/discussions/issues/195#issuecomment-1973732769


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

With this new tag, it would be used for topics that are not for the TC meetings but are for the working meetings. Currently, only the 'Top Priority' tag is followed, but this is for things that absolutely need to be done.  

There are discussions that only have the 'Meeting' tag, which means they would never appear on the agenda.