### PR TITLE
docs: add general labels documentation for issues and PRs

### DIFF
--- a/docs/triage/labels.md
+++ b/docs/triage/labels.md
@@ -1,0 +1,38 @@
+# General labels
+
+Express has the following labels available to tag each issue and PR that has been opened
+
+| Name                 | Description                                                                         |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| `bug`                | Denotes confirmed bugs.                                                             |
+| `duplicate`          | A duplicate issue.                                                                  |
+| `enhancement`        | An issue requesting an enhancement.                                                 |
+| `help wanted`        | Extra help may be needed to resolve this issue.                                     |
+| `invalid`            | This is not a proper issue report, request, or question.                            |
+| `question`           | For issues where the issuer is asking something.                                    |
+| `wontfix`            | Marks an issue that will not be fixed.                                              |
+| `docs`               | This issue pertains to the documentation or code comments.                          |
+| `investigate`        | Requires further investigation.                                                     |
+| `tests`              | This issue pertains to the tests themselves.                                        |
+| `deprecate`          | Issue is about a feature that is pending future removal.                            |
+| `release`            | A tracking issue for a specific release milestone.                                  |
+| `ideas`              | Marks an issue which is primarily an idea.                                          |
+| `discuss`            | This issue should remain open to discussion for a while.                            |
+| `needs tests`        | This pull request needs tests to be added.                                          |
+| `needs docs`         | This pull request needs documentation to be added.                                  |
+| `needs rebase`       | This pull request needs rebase to be added.                                         |
+| `future`             | An issue which should be resolved in a future release.                              |
+| `deps`               | Marks a dependancy-related issue or pull request.                                   |
+| `low priority`       | Denotes a low-priority issue.                                                       |
+| `question`           | Issues that look for answers.                                                       |
+| `tc agenda`          | Issues that will be discussed in the TC meetings.                                   |
+| `top priority`       | Issues that will be discussed in the working sessions.                              |
+| `fast track`         | PRs that are quick changes, like fixing a spelling mistake.                         |
+| `meta`               | Issues and PRs related to the general management of the project.                    |
+| `semver-major`       | PRs that have a breaking change.                                                    |
+| `semver-minor`       | PRs that add a new feature and do not break compatibility.                          |
+| `semver-patch`       | PRs that fix a bug in the code without breaking compatibility.                      |
+| `feedback`           | PRs that require feedback from the community.                                       |
+| `require-triage`     | Issues and PRs that have been opened but have not been reviewed for the first time. |
+| `awaiting more info` | Issues that require more information for better understanding.                      |
+| `good first issue`   | Issues suitable for newcomers to fix                                                |


### PR DESCRIPTION
This was discussed in #294 about having the labels documented at the organizational level, so that new triagers know how to use them. Part of this was extracted from https://github.com/jshttp/style-guide?tab=readme-ov-file#issue-label-use.