### PR TITLE
fix: update meeting schedules to reflect new time adjustments

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -19,8 +19,8 @@ jobs:
           agendaLabel: 'tc agenda'
           meetingLabels: 'meeting'
           # https://github.com/expressjs/discussions/issues/195#issuecomment-1973732769
-          # Starting on 2024-03-18 at 9pm UTC (2024-03-18T21:00:00.0Z) with a period of 2 weeks (P2W)
-          schedules: '2024-03-18T21:00:00.0Z/P2W'
+          # Starting on 2024-03-18 at 8pm UTC (2024-03-18T20:00:00.0Z) with a period of 2 weeks (P2W)
+          schedules: '2024-03-18T20:00:00.0Z/P2W'
           createWithin: 'P1W'
           meetingLink: 'https://zoom-lfx.platform.linuxfoundation.org/meeting/95266714809?password=f37cff1b-cb3a-4a21-9425-210e4714c72e'
           issueTemplate: 'meeting.md'
@@ -35,8 +35,8 @@ jobs:
           meetingLabels: 'meeting'
           # Converting the second time slot to a "working session"
           # https://github.com/expressjs/discussions/issues/195#issuecomment-1973732769
-          # Starting on 2024-03-27 at 9pm UTC (2024-03-27T21:00:00.0Z) with a period of 2 weeks (P2W)
-          schedules: '2024-03-27T21:00:00.0Z/P2W'
+          # Starting on 2024-03-27 at 8pm UTC (2024-03-27T20:00:00.0Z) with a period of 2 weeks (P2W)
+          schedules: '2024-03-27T20:00:00.0Z/P2W'
           createWithin: 'P1W'
           meetingLink: 'https://zoom-lfx.platform.linuxfoundation.org/meeting/95258037175?password=07aad89d-ff43-45df-9b28-f437e167a0b9'
           issueTemplate: 'meeting.md'
@@ -49,7 +49,7 @@ jobs:
           agendaLabel: 'triage-meeting'
           meetingLabels: 'meeting'
           # https://github.com/expressjs/discussions/issues/276#issuecomment-2399741373
-          # Starting on 2025-01-27 at 8pm UTC (2025-01-27T20:00:00.0Z) with a period of 4 weeks (P4W)
-          schedules: '2025-01-27T20:00:00.0Z/P4W'
+          # Starting on 2025-01-27 at 7pm UTC (2025-01-27T19:00:00.0Z) with a period of 4 weeks (P4W)
+          schedules: '2025-01-27T19:00:00.0Z/P4W'
           createWithin: 'P1W'
           issueTemplate: 'meeting-triage.md'


### PR DESCRIPTION
Once again, time changes according to my calendar