### PR TITLE
docs: clarify release authorization and permissions in release process

### DIFF
--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -7,7 +7,10 @@ package governed by Express.
 
 ## Who can make releases?
 
-According to project governance, only package Captains or members of the Technical Committee (TC) are permitted to make releases. Captains have the freedom to make releases for their own package whenever necessary, while TC members may make releases for any package as needed.
+According to project governance, only package Captains or members of the Technical
+Committee (TC) are permitted to make releases. Captains have the freedom to make releases
+for their own package whenever necessary, while TC members may make releases for any package
+as needed.
 
 ### 1. Github release access
 


### PR DESCRIPTION
If two captains are not part of the TC, and the other captain gives authorization to release the package, is that valid? Or does there always have to be authorization from the TC?