### PR TITLE
meetings: remove PR and push triggers, add workflow_dispatch

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -1,9 +1,6 @@
 name: Schedule Meetings
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -1,6 +1,10 @@
 name: Schedule Meetings
 on:
   workflow_dispatch:
+  pull_request:
+      paths:
+        - '.github/workflows/meetings.yml'
+        - '.github/ISSUE_TEMPLATE/meeting.md'
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
Idk if we need/want to run it on PR and push?

At the least though, adding the workflow_dispatch option would be very useful so we can run them on demand