### PR TITLE
docs: add Typescript captains members

### DIFF
--- a/docs/contributing/captains_and_committers.md
+++ b/docs/contributing/captains_and_committers.md
@@ -85,6 +85,7 @@
 - [Triage team](https://github.com/expressjs/discussions/issues/227): @UlisesGascon
 - [Security WG](https://github.com/expressjs/security-wg): @UlisesGascon
 - [Perf WG](https://github.com/expressjs/perf-wg): @wesleytodd
+- [Typescript WG](https://github.com/expressjs/typescript-wg): @jonchurch, @bjohansebas
 - Archived repos and deprecated packages: @UlisesGascon
 
 ## Accounts details


### PR DESCRIPTION
ref: https://github.com/expressjs/typescript-wg?tab=readme-ov-file#team-members

cc: @expressjs/express-tc @expressjs/typescript-wg-captians 