### PR TITLE
fix(docs): Add @bjohansebas as Triage Team captain

### DIFF
--- a/docs/contributing/captains_and_committers.md
+++ b/docs/contributing/captains_and_committers.md
@@ -82,7 +82,7 @@
 
 ## Current Initiative Captains
 
-- [Triage team](https://github.com/expressjs/discussions/issues/227): @UlisesGascon
+- [Triage team](https://github.com/expressjs/discussions/issues/227): @UlisesGascon, @bjohansebas
 - [Security WG](https://github.com/expressjs/security-wg): @UlisesGascon
 - [Perf WG](https://github.com/expressjs/perf-wg): @wesleytodd
 - Archived repos and deprecated packages: @UlisesGascon


### PR DESCRIPTION
Nominating @bjohansebas as a captain of the Triage Team. We have seen lots of *great* contributions from @bjohansebas this year and he is interested in helping run this effort. Thanks for the continue hard work to help make sure the project runs smoothly.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
