### PR TITLE
docs: update expressjs.com members and add emeritus section

### DIFF
--- a/docs/contributing/captains_and_committers.md
+++ b/docs/contributing/captains_and_committers.md
@@ -19,7 +19,7 @@
   - committers: @bjohansebas, @Phillip9587
 - [`expressjs/expressjs.com`](https://github.com/expressjs/expressjs.com):
   - captains: @crandmck, @jonchurch, @bjohansebas
-  - committers: @ShubhamOulkar
+  - committers: @carlosstenzel @ShubhamOulkar
 - [`expressjs/generator`](https://github.com/expressjs/generator): @wesleytodd
 - [`expressjs/method-override`](https://github.com/expressjs/method-override): @ulisesGascon
 - [`expressjs/morgan`](https://github.com/expressjs/morgan): @jonchurch, @ulisesGascon

--- a/docs/contributing/captains_and_committers.md
+++ b/docs/contributing/captains_and_committers.md
@@ -19,7 +19,7 @@
   - committers: @bjohansebas, @Phillip9587
 - [`expressjs/expressjs.com`](https://github.com/expressjs/expressjs.com):
   - captains: @crandmck, @jonchurch, @bjohansebas
-  - committers: @carlosstenzel, @chrisdel101, @ShubhamOulkar
+  - committers: @ShubhamOulkar
 - [`expressjs/generator`](https://github.com/expressjs/generator): @wesleytodd
 - [`expressjs/method-override`](https://github.com/expressjs/method-override): @ulisesGascon
 - [`expressjs/morgan`](https://github.com/expressjs/morgan): @jonchurch, @ulisesGascon
@@ -101,3 +101,9 @@
 - @seplu (npm: [~sheplu](https://www.npmjs.com/~sheplu))
 - @ulisesGascon (npm: [~ulisesgascon](https://www.npmjs.com/~ulisesgascon))
 - @wesleytodd (npm: [~wesleytodd](https://www.npmjs.com/~wesleytodd))
+
+## Emeritus Members
+
+- [`expressjs/expressjs.com`](https://github.com/expressjs/expressjs.com):
+  - triage: @juliogarciape @inigomarquinez
+  - committers: @carlosstenzel, @chrisdel101

--- a/docs/contributing/captains_and_committers.md
+++ b/docs/contributing/captains_and_committers.md
@@ -106,4 +106,4 @@
 
 - [`expressjs/expressjs.com`](https://github.com/expressjs/expressjs.com):
   - triage: @juliogarciape @inigomarquinez
-  - committers: @carlosstenzel, @chrisdel101
+  - committers: @chrisdel101


### PR DESCRIPTION
per https://github.com/expressjs/discussions/blob/master/docs/GOVERNANCE.md#inactivity-and-emeritus-policy-for-any-role moving @carlosstenzel, @chrisdel101, @juliogarciape, and @inigomarquinez to emeritus status, as they've been inactive for 6+ months

I've removed them from the relevant teams, let me know if they want to be added back to the teams, either here or on Slack, and I'll add them back 😊

and thanks a lot for all their contributions