### PR TITLE
docs: update link for Triager Guide in GOVERNANCE.md

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -61,7 +61,7 @@ compromise among committers be the default resolution mechanism.
 ## Becoming a Triager
 
 Anyone can become a triager! Read more about the process of being a triager in
-[the triage process document](Triager-Guide.md).
+[the triage process document](contributing/triager-guide.md).
 
 Currently, any existing [organization member](https://github.com/orgs/expressjs/people) can nominate
 a new triager. If you are interested in becoming a triager, our best advice is to actively participate


### PR DESCRIPTION
Closes #438.

The 'Becoming a Triager' section in \`docs/GOVERNANCE.md\` links to \`Triager-Guide.md\`, which 404s for two reasons:

1. The file is named \`triager-guide.md\` (lowercase). GitHub blob URLs are case-sensitive.
2. It lives under \`docs/contributing/\`, not alongside \`GOVERNANCE.md\`.

Update the relative link to \`contributing/triager-guide.md\` so it resolves correctly from \`docs/GOVERNANCE.md\` to the existing file. Verified the target file exists at \`docs/contributing/triager-guide.md\` and starts with \"# Express Triager Guide\".

Docs only.