### PR TITLE
docs: remove @bjohansebas from the Triage Captain and TypeScript Captain

### DIFF
--- a/docs/contributing/captains_and_committers.md
+++ b/docs/contributing/captains_and_committers.md
@@ -84,10 +84,10 @@
 
 ## Current Initiative Captains
 
-- [Triage team](https://github.com/expressjs/discussions/issues/227): @UlisesGascon, @bjohansebas
+- [Triage team](https://github.com/expressjs/discussions/issues/227): @UlisesGascon
 - [Security WG](https://github.com/expressjs/security-wg): @UlisesGascon
 - [Perf WG](https://github.com/expressjs/perf-wg): @wesleytodd
-- [Typescript WG](https://github.com/expressjs/typescript-wg): @jonchurch, @bjohansebas
+- [Typescript WG](https://github.com/expressjs/typescript-wg): @jonchurch
 - Archived repos and deprecated packages: @UlisesGascon
 
 ## Accounts details
@@ -109,3 +109,5 @@
 - [`expressjs/expressjs.com`](https://github.com/expressjs/expressjs.com):
   - triage: @juliogarciape @inigomarquinez
   - committers: @chrisdel101
+- [Triage team](https://github.com/expressjs/discussions/issues/227): @bjohansebas
+- [Typescript WG](https://github.com/expressjs/typescript-wg): @bjohansebas


### PR DESCRIPTION
As I mentioned to Ulises privately, the project has been stagnant in many areas, and now that I have the energy/time, I’m not really sure where to focus anymore.

My roles as a Triage Captain don’t really help much in terms of driving things forward; it’s mostly approving or requesting changes and reviewing. I’ll just stay focused on the packages where I’m a Captain (and, obviously, docs — I love docs 😄), as well as the QUIC and Fetch model work that Node.js is going to adopt. I’ve already done quite a bit of research on that, and I’d like to help make sure someone picks it up from here so Express can at least evolve alongside Node.js instead of remaining stuck in HTTP/1 forever. Ideally, we should move toward something based on the standards coming out of WinterTC.

By the way, I think there are some things we need to change in the governance to make this less bureaucratic. Attending a meeting shouldn’t be a hard requirement to be a TC member, or at least to become a Captain. Some of us already have the trust of other major projects and even the Foundation itself, and we know what it means to take ownership of a package.

A meeting isn’t going to triage 200+ issues, make releases, or handle the security work across the entire project. :) Just as a reflection, though, several people here are doing an amazing job and are genuinely great at what they do.

I really hope Express keeps evolving and doesn’t fall back into stagnation again. I know there are a lot of packages, but the only really active area seems to be the `jshttp` org, and I’m only interested in a few of them, so I’m not really sure how I can help there either.


cc: @expressjs/express-tc @expressjs/triagers @expressjs/typescript-wg  (Regarding the change in captains.)